### PR TITLE
Don't allow the same argument to be set twice in one call

### DIFF
--- a/np.tcl
+++ b/np.tcl
@@ -61,7 +61,6 @@ namespace eval ::np {
 	#   expected way.
 	#
 	::proc np_handler {argd realArgs} {
-		array set vsets [dict get $argd defaults]
 		set named [dict get $argd named]
 		set positional [dict get $argd positional]
 
@@ -97,8 +96,22 @@ namespace eval ::np {
 
 			# we're good, set the named parameter into the variable sets
 			#puts [list set vsets($var) [lindex $realArgs 1]]
+
+			# but don't allow the same variable to be set twice
+			if {[info exists vsets($var)]} {
+				error [dict get $argd errmsg] "" [list TCL WRONGARGS]
+			}
+
 			set vsets($var) [lindex $realArgs 1]
 			set realArgs [lrange $realArgs 2 end]
+		}
+
+		# fill in defaults for all the vars with defaults that
+		# didn't get set to a value
+		foreach "var value" [dict get $argd defaults] {
+			if {![info exists vsets($var)]} {
+				set vsets($var) $value
+			}
 		}
 
 		foreach var $positional {


### PR DESCRIPTION
The original Tcl implementation of named parameters supported specifying the same argument multiple times.  For example, "foo -b 1 -b 2" and it just used the last value set.

The C implementation was made much simplier, touching less code in fewer places, by making the forementioned practice an error.  We agreed to do that, changed one of the np tests accordingly, and the C implementation was developed and shown to pass all of the tests of the Tcl version.

However, we didn't bring the Tcl version into compliance with the C behavior.  This PR bring the Tcl version into compliance and so now once again the Tcl version will be able to pass all the tetss.